### PR TITLE
Add Ubuntu 18.04 build

### DIFF
--- a/FFmpeg.Native/FFmpeg.Native.csproj
+++ b/FFmpeg.Native/FFmpeg.Native.csproj
@@ -5,6 +5,7 @@
     <FFmpegWin64Dir Condition="'$(FFmpegWin64Dir)' == ''">$(SYSTEM_ARTIFACTSDIRECTORY)/ffmpeg/win7-x64/usr/local/</FFmpegWin64Dir>
     <FFmpegWin32Dir Condition="'$(FFmpegWin32Dir)' == ''">$(SYSTEM_ARTIFACTSDIRECTORY)/ffmpeg/win7-x86/usr/local/</FFmpegWin32Dir>
     <FFmpegOSXDir Condition="'$(FFmpegOSXDir)' == ''">$(SYSTEM_ARTIFACTSDIRECTORY)/ffmpeg/osx-x64/usr/local/</FFmpegOSXDir>
+    <FFmpegLinuxDir Condition="'$(FFmpegLinuxDir)' == ''">$(SYSTEM_ARTIFACTSDIRECTORY)/ffmpeg/linux-x64/usr/local/</FFmpegLinuxDir>
     <PackageIconUrl>https://ffmpeg.org/favicon.ico</PackageIconUrl>
     <Authors>FFmpeg Team</Authors>
     <Company></Company>
@@ -39,6 +40,11 @@
 
     <Content Include="$(FFmpegOSXDir)/lib/*.dylib">
       <PackagePath>runtimes/osx-x64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+
+    <Content Include="$(FFmpegLinuxDir)/lib/*.so">
+      <PackagePath>runtimes/linux-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
   </ItemGroup>

--- a/FFmpeg.Native/WindowsBinaries.cs
+++ b/FFmpeg.Native/WindowsBinaries.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Reflection;
 
@@ -24,7 +25,19 @@ namespace FFmpeg.Native
 
             // Alternatively, try the "runtimes" directory. This is the layout when this assembly
             // is loaded from a NuGet package (i.e. unit testing,...)
-            var nativeDirectory = Path.Combine(assemblyDirectory, "../../runtimes/win7-x64/native/");
+            var nativeDirectory = Path.Combine(assemblyDirectory, "../../runtimes");
+            
+            if (Environment.Is64BitProcess)
+            {
+                nativeDirectory = Path.Combine(nativeDirectory, "win7-x64");
+            }
+            else
+            {
+                nativeDirectory = Path.Combine(nativeDirectory, "win7-x86");
+            }
+            
+            nativeDirectory = Path.Combine(nativeDirectory, "native");
+            
             fullFileName = Path.Combine(nativeDirectory, fileName);
 
             if (File.Exists(fullFileName))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,8 +66,8 @@ jobs:
       sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
     displayName: Set up sudo
   - script: |
-      sudo apt-get install -y patchelf
-    displayName: Set up patchelf
+      sudo apt-get install -y build-essential patchelf gcc g++ yasm libunwind8 wget
+    displayName: Set up patchelf, wget, compiler
   - script: |
       wget -nv -nc http://ffmpeg.org/releases/ffmpeg-$(FFMPEG_VERSION).tar.bz2 -O ffmpeg-$(FFMPEG_VERSION).tar.bz2
       tar xjf ffmpeg-$(FFMPEG_VERSION).tar.bz2
@@ -80,14 +80,14 @@ jobs:
     workingDirectory: ffmpeg-$(FFMPEG_VERSION)
     displayName: Build FFmpeg
   - script:
-      make DESTDIR=$(Build.ArtifactStagingDirectory)/ubuntu.18.04-x64 install
+      make DESTDIR=$(Build.ArtifactStagingDirectory)/linux-x64 install
     workingDirectory: ffmpeg-$(FFMPEG_VERSION)
     displayName: Install FFmpeg
   - script: |
-      for f in $(Build.ArtifactStagingDirectory)/ubuntu.18.04-x64/usr/local/lib/*.so.*; do
+      for f in $(Build.ArtifactStagingDirectory)/linux-x64/usr/local/lib/*.so.*; do
         chmod +w $f
 
-        $patchelf --set-rpath '${ORIGIN}' $f
+        patchelf --set-rpath '${ORIGIN}' $f
 
         readelf -d $f
       done

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,6 +54,48 @@ jobs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: ffmpeg
 
+- job: ubuntu
+  pool:
+    vmImage: ubuntu-16.04
+  container:
+    image: ubuntu:18.04
+    options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
+  steps:
+  - script: |
+      /tmp/docker exec -t -u 0 ci-container \
+      sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
+    displayName: Set up sudo
+  - script: |
+      sudo apt-get install -y patchelf
+    displayName: Set up patchelf
+  - script: |
+      wget -nv -nc http://ffmpeg.org/releases/ffmpeg-$(FFMPEG_VERSION).tar.bz2 -O ffmpeg-$(FFMPEG_VERSION).tar.bz2
+      tar xjf ffmpeg-$(FFMPEG_VERSION).tar.bz2
+    displayName: Download FFmpeg
+  - script: |
+      # See https://github.com/FFmpeg/FFmpeg/blob/master/configure for an overview of all configuration
+      # options
+      ./configure --arch=x86_64 --disable-static --enable-shared --enable-version3
+      make
+    workingDirectory: ffmpeg-$(FFMPEG_VERSION)
+    displayName: Build FFmpeg
+  - script:
+      make DESTDIR=$(Build.ArtifactStagingDirectory)/ubuntu.18.04-x64 install
+    workingDirectory: ffmpeg-$(FFMPEG_VERSION)
+    displayName: Install FFmpeg
+  - script: |
+      for f in $(Build.ArtifactStagingDirectory)/ubuntu.18.04-x64/usr/local/lib/*.so.*; do
+        chmod +w $f
+
+        $patchelf --set-rpath '${ORIGIN}' $f
+
+        readelf -d $f
+      done
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: ffmpeg
+
 - job: macos
   pool:
     vmImage: 'macOS-10.15'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,12 +42,20 @@ jobs:
       make
     workingDirectory: ffmpeg-$(FFMPEG_VERSION)
     displayName: Build FFmpeg
-  - script:
+  - script: |
       make DESTDIR=$(Build.ArtifactStagingDirectory)/$(rid) install
     workingDirectory: ffmpeg-$(FFMPEG_VERSION)
     displayName: Install FFmpeg
-  - script:
-      cp /usr/$(crossPrefix)/lib/libwinpthread-1.dll $(Build.ArtifactStagingDirectory)/$(rid)/usr/local/bin
+  - script: |
+      libgcc="/usr/lib/gcc/$(crossPrefix)/7.3-posix/libgcc_s_sjlj-1.dll"
+
+      if [ -f "$libgcc" ]; then
+        echo "$libgcc exist"
+        cp $libgcc $(Build.ArtifactStagingDirectory)/$(rid)/usr/local/bin/
+      fi
+
+      cp /usr/$(crossPrefix)/lib/libwinpthread-1.dll $(Build.ArtifactStagingDirectory)/$(rid)/usr/local/bin/
+      
     displayName: Copy additional libraries
   - task: PublishBuildArtifacts@1
     inputs:


### PR DESCRIPTION
- Add Ubuntu 18.04 build
- Fix handling of runtime ID on 32-bit Windows (`win7-x86` vs `win7-x64`)
- Include `libgcc_s_sjlj-1.dll` for `win7-x86`.