### PR TITLE
Fix packaging

### DIFF
--- a/FFmpeg.Native/FFmpeg.Native.csproj
+++ b/FFmpeg.Native/FFmpeg.Native.csproj
@@ -38,12 +38,12 @@
       <Pack>true</Pack>
     </Content>
 
-    <Content Include="$(FFmpegOSXDir)/lib/*.dylib">
+    <Content Include="$(FFmpegOSXDir)/lib/lib*.*.dylib" Exclude="$(FFmpegOSXDir)/lib/lib*.*.*.*.dylib">
       <PackagePath>runtimes/osx-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
 
-    <Content Include="$(FFmpegLinuxDir)/lib/*.so">
+    <Content Include="$(FFmpegLinuxDir)/lib/lib*.so.*" Exclude="$(FFmpegLinuxDir)/lib/lib*.so;$(FFmpegLinuxDir)/lib/lib*.so.*.*.*">
       <PackagePath>runtimes/linux-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,7 +137,7 @@ jobs:
         chmod +w "$f"
 
         # Skip the first two lines of the otool output, this is just the name of the dylib itself
-        dylibs=`otool -L "$f" | tail -n +3 | grep "/usr/local/lib/" | awk -F' ' '{ print $1 }'`
+        dylibs=`otool -L "$f" | tail -n +3 | grep "/usr/local/" | awk -F' ' '{ print $1 }'`
 
         for dylib in $dylibs; do
           basename=`basename "$dylib"`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,10 +122,13 @@ jobs:
       make
     workingDirectory: ffmpeg-$(FFMPEG_VERSION)
     displayName: Build FFmpeg
-  - script:
+  - script: |
       make DESTDIR=$(Build.ArtifactStagingDirectory)/osx-x64 install
     workingDirectory: ffmpeg-$(FFMPEG_VERSION)
     displayName: Install FFmpeg
+  - script: |
+      cp /usr/local/opt/xz/lib/liblzma.5.dylib $(Build.ArtifactStagingDirectory)/osx-x64/usr/local/lib
+    displayName: Copy additional libraries
   - script: |
       out="$(Build.ArtifactStagingDirectory)/osx-x64/usr/local/lib"
 


### PR DESCRIPTION
- Only include required `.so` and `.dylib` files (exclude symlinks)
- Include liblzma on macOS